### PR TITLE
Reduce LED blink time to 50ms

### DIFF
--- a/src/signalCounter.c
+++ b/src/signalCounter.c
@@ -240,7 +240,7 @@ void ledBlink(int durationMs)
  */
 PI_THREAD(ledSignalCounted)
 {
-    ledBlink(300);
+    ledBlink(50);
 }
 
 void processCountFile(void)
@@ -360,7 +360,7 @@ void signalIsr(void)
 
     // blink the LED to show we recorded the signal
     //piThreadCreate(ledSignalCounted);
-    ledBlink(200);
+    ledBlink(50);
 
     // attempt to submit the count file
     // disable - threads become unresponsive after a while. Rely on main loop call to processCountFile();


### PR DESCRIPTION
Blinking the LED blocks code execution, increasing the interval required between recording hits.

With the LED blink interval at 300ms and a trigger interval of 150ms, for instance, the maximum number of hits we could detect in a minute is 150 (assuming all processing happens in realtime).

This PR lowers the blink interval to 50ms, allowing a higher frequency of hits.